### PR TITLE
Fix form payload handling in GoCoax API

### DIFF
--- a/custom_components/gocoax/gocoax_api.py
+++ b/custom_components/gocoax/gocoax_api.py
@@ -100,9 +100,24 @@ class GoCoaxAPI:
             headers['X-CSRF-TOKEN'] = csrf_token
             headers['Cookie'] = f'csrf_token={csrf_token}'
 
-        resp = self._session.post(url, json=data_to_send, headers=headers, verify=False)
+        if payload_format == 'json':
+            resp = self._session.post(
+                url, json=data_to_send, headers=headers, verify=False
+            )
+        else:
+            resp = self._session.post(
+                url, data=data_to_send, headers=headers, verify=False
+            )
+
         resp.raise_for_status()
-        return resp.json()
+
+        # When sending form encoded data the response might not be JSON, but
+        # all current callers expect JSON. In case the server returns non JSON
+        # just return an empty dictionary which matches the previous behaviour
+        try:
+            return resp.json()
+        except ValueError:
+            return {}
 
     def get_data(self, action_url, referer=None, debug=False):
         url = self._base_url + action_url


### PR DESCRIPTION
## Summary
- fix GoCoaxAPI.post_data to use form payloads correctly and handle non-JSON responses

## Testing
- `python -m py_compile custom_components/gocoax/*.py`