### PR TITLE
Fix async step error handling

### DIFF
--- a/custom_components/gocoax/config_flow.py
+++ b/custom_components/gocoax/config_flow.py
@@ -55,7 +55,8 @@ class GoCoaxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     },
                 )
             else:
-                errors["base"] = "cannot_connect"
+                if "base" not in errors:
+                    errors["base"] = "cannot_connect"
 
         # If no user_input yet, or connection failed, show the form again
         data_schema = vol.Schema(

--- a/custom_components/gocoax/translations/en.json
+++ b/custom_components/gocoax/translations/en.json
@@ -13,7 +13,8 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect, check credentials or device."
+      "cannot_connect": "Failed to connect, check credentials or device.",
+      "unknown": "Unknown error occurred."
     }
   }
 }


### PR DESCRIPTION
## Summary
- don't overwrite existing error in user step
- add 'unknown' error translation

## Testing
- `pytest` *(fails: command not found)*